### PR TITLE
alpha updates

### DIFF
--- a/mod/patch.json
+++ b/mod/patch.json
@@ -427,14 +427,6 @@
 				"polyplusstatic"
 			]
 		},
-		"shaman": {
-			"health": 100,
-			"defence": 10,
-			"attack": 15,
-			"promotionLimit": 3,
-			"unitAbilities": [
-				"boost"
-			],
 		"polytaur": {
 			"health": 150,
 			"defence": 10,
@@ -548,10 +540,12 @@
 			]
 		},
 		"shaman": {
+			"health": 100,
+			"defence": 10,
+			"attack": 15,
+			"promotionLimit": 3,
 			"unitAbilities": [
-				"convert",
-				"boost",
-				"polyplusstatic"
+				"boost"
 			]
 		},
 		"dagger": {

--- a/mod/patch.json
+++ b/mod/patch.json
@@ -6,7 +6,8 @@
 			},
 			"techOverrides": {
 				"sailing": "sailing2"
-			}
+			},
+			"startingUnit": "mindbender"
 		},
 		"aquarion": {
 			"unitOverrides": {
@@ -154,17 +155,22 @@
 			"resourceModifier": {
 				"aquacrop": 0.5
 			},
+			"unitOverrides": {
+				"mindbender": "mindbender"
+			},
 			"improvementOverrides": {
 				"port": "none",
 				"customshouse": "none"
 			},
 			"techOverrides": {
+				"roads": "cymroads",
 				"construction": "recycling",
 				"chivalry": "shock",
 				"aquaculture": "aquaculture",
 				"sailing": "hydrology",
 				"navigation": "pescetism"
-			}
+			},
+			"startingUnit": "warrior"
 		}
 	},
 	"techData": {
@@ -291,6 +297,18 @@
 			},
 			"cost": 1
 		},
+		"cymroads": {
+			"techUnlocks": [
+				"trade"
+			],
+			"unitUnlocks": [
+				"shaman"
+			],
+			"improvementUnlocks": [
+				"mycelium"
+			],
+			"cost": 2
+		},
 		"spearing": {
 			"abilityUnlocks": [
 				"destroy"
@@ -409,6 +427,14 @@
 				"polyplusstatic"
 			]
 		},
+		"shaman": {
+			"health": 100,
+			"defence": 10,
+			"attack": 15,
+			"promotionLimit": 3,
+			"unitAbilities": [
+				"boost"
+			],
 		"polytaur": {
 			"health": 150,
 			"defence": 10,

--- a/mod/patch.json
+++ b/mod/patch.json
@@ -20,6 +20,7 @@
 				"aquacrop": 0.5
 			},
 			"improvementOverrides": {
+				"fertilize": "aquafertilize",
 				"port": "none",
 				"customshouse": "none"
 			}
@@ -663,6 +664,24 @@
 				"consumed"
 			],
 			"maxLevel": 0
+		},
+		"aquafertilize": {
+			"cost": 5,
+			"terrainRequirements": [
+				{
+					"terrain": "wetland"
+				}
+			],
+			"creates": [
+				{
+					"resource": "crop"
+				}
+			],
+			"improvementAbilities": [
+				"consumed"
+			],
+			"maxLevel": 0,
+			"idx": -1
 		},
 		"fungi": {
 			"cost": 7

--- a/mod/patch.json
+++ b/mod/patch.json
@@ -307,7 +307,8 @@
 			"improvementUnlocks": [
 				"mycelium"
 			],
-			"cost": 2
+			"cost": 2,
+			"idx": -1
 		},
 		"spearing": {
 			"abilityUnlocks": [


### PR DESCRIPTION
- Cymanti gains access to mindbenders
- Shaman is moved to Roads
- Shaman loses the ability to convert enemy units
- Shaman attack 1 -> 1.5
- Aquarion gets their own version of Fertilize
- Ai-Mo starts with a mindbender