### PR TITLE
Naval changes

### DIFF
--- a/PolyPlus/patch.json
+++ b/PolyPlus/patch.json
@@ -362,6 +362,10 @@
 			"cost": 2
 		},
 		"polarwarfare": {
+			"unitUnlocks": [
+				"icefortress",
+				"wendi"
+			],
 			"improvementUnlocks": [
 			]
 		},
@@ -439,6 +443,7 @@
 			]
 		},
 		"scout": {
+			"cost": 5,
 			"unitAbilities": [
 				"dash",
 				"polyplusstatic"
@@ -500,24 +505,58 @@
 		},
 		"mooni": {
 			"health": 100,
-			"defence": 10,
+			"defence": 20,
 			"movement": 1,
 			"range": 1,
 			"attack": 0,
-			"cost": 5,
+			"cost": 3,
 			"unitAbilities": [
-				"skate",
-				"freezearea"
+				"polyplusstatic",
+				"stiff",
+				"freezearea",
+				"glide"
 			]
 		},
 		"gaami": {
 			"unitAbilities": [
 				"autofreeze",
 				"freezearea",
-				"polyplusstatic"
+				"polyplusstatic",
+				"glide"
 			]
 		},
-		
+		"wendi": {
+			"health": 100,
+			"defence": 0,
+			"movement": 2,
+			"range": 1,
+			"attack": 0,
+			"cost": 8,
+			"unitAbilities": [
+				"skate",
+				"freezearea",
+				"autofreeze",
+				"stiff",
+				"polyplusstatic"
+			],
+			"weapon": 7,
+			"promotionLimit": 3,
+			"prefab": "mooni",
+			"idx": -1
+		},
+		"icefortress": {
+			"health": 200,
+			"defence": 30,
+			"movement": 1,
+			"range": 2,
+			"attack": 40,
+			"cost": 10,
+			"unitAbilities": [
+				"skate",
+				"scout",
+				"dash"
+			]
+		},
 		"hexapod": {
 			"unitAbilities": [
 				"dash",
@@ -614,7 +653,7 @@
 			"movement": 2,
 			"range": 3,
 			"attack": 40,
-			"cost": 15,
+			"cost": 10,
 			"hidden": true,
 			"upgradesFrom": "transportship",
 			"unitAbilities": [
@@ -625,6 +664,7 @@
 			]
 		},
 		"scoutship": {
+			"cost": 3,
 			"unitAbilities": [
 				"dash",
 				"carry",
@@ -791,6 +831,9 @@
 	},
 	"unitAbility": {
 		"polyplusstatic": {
+			"idx": -1
+		},
+		"glide": {
 			"idx": -1
 		}
 	},

--- a/PolyPlusPatcher.cs
+++ b/PolyPlusPatcher.cs
@@ -227,12 +227,18 @@ namespace PolyPlus {
 
         [HarmonyPostfix]
         [HarmonyPatch(typeof(TileData), nameof(TileData.GetMovementCost))]
-        private static void TileData_GetMovementCost(ref int __result, MapData map, TileData fromTile, PathFinderSettings settings)
+        private static void TileData_GetMovementCost(ref int __result, TileData __instance, MapData map, TileData fromTile, PathFinderSettings settings)
         {
-            UnitState unit = settings.unit;
+            var unit = settings.unit;
             if (unit != null && __result == 5 && settings.unitData.HasAbility(UnitAbility.Type.Skate))
             {
                 __result = 10;
+            }
+            if (unit != null &&
+                __instance.terrain == TerrainData.Type.Ice &&
+                settings.unitData.HasAbility(EnumCache<UnitAbility.Type>.GetType("glide")))
+            {
+                __result = 5;
             }
         }
 


### PR DESCRIPTION
Scout cost 5 -> 3
Bomber cost 15 -> 10
Fortress cost 15 -> 10 
Fortress gained dash
"Glide" ability added. gives double movement, similar to Polarism
Mooni gained glide, lost skate
Mooni cost 5 -> 3
Mooni defense 1 -> 2
Gaami gained glide
New Polaris unit
- Tech: Polar Warfare
- Cost: 8
- Movement:2
- Defense: 0, Health: 10
- Attack: 0
- Skate, Freeze Area, Auto Freeze
- Name pending

I'd love to change auto freeze with dash freeze here, but just giving something dash along with freeze area isn't working